### PR TITLE
Přesměrování na outro na konci scénáře + odlišené vizuální styly

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,10 +134,17 @@ def chat():
     scenario = import_module(session["scenario"])
     bot_reply = scenario.reply(user_reply, user.nick, conversation_state)
     session.modified = True
-    db.session.add(Reply(user_id=user.id, content=bot_reply))
+    if bot_reply is None:
+        session["page"] = "outro"
+        response = redirect(url_for("dispatcher"))
+    else:
+        db.session.add(Reply(user_id=user.id, content=bot_reply))
+        response = render_template(
+            "chat.html", bot_reply=bot_reply, scenario=scenario.__name__
+        )
 
     db.session.commit()
-    return render_template("chat.html", bot_reply=bot_reply, scenario=scenario.__name__)
+    return response
 
 
 def outro():

--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ def dispatcher():
         scenario = import_module(session["scenario"])
         for attr in ("bg_color", "heading_color", "heading_outline"):
             setattr(g, attr, getattr(scenario, attr, None))
-    except:
+    except ImportError:
         pass
 
     if request.args.get("end"):

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from flask import (
     Flask,
     abort,
+    g,
     redirect,
     render_template,
     request,
@@ -85,6 +86,13 @@ def dispatcher():
         # starting a conversation without setting a scenario is
         # forbidden -> 403 error
         return render_template("forbidden.html"), 403
+
+    try:
+        scenario = import_module(session["scenario"])
+        for attr in ("bg_color", "heading_color", "heading_outline"):
+            setattr(g, attr, getattr(scenario, attr, None))
+    except:
+        pass
 
     if request.args.get("end"):
         session["page"] = "outro"

--- a/scenario1.py
+++ b/scenario1.py
@@ -1,4 +1,7 @@
 description = "Scénář 1 není určen ke zdvořilostní konverzaci, nýbrž pouze k testování."
+bg_color = "blue"
+heading_color = "green"
+heading_outline = "red"
 
 
 def reply(user_reply, nick, conversation_state):

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
   <style>
 body {
   font-family: Helvetica;
-  background-color: DarkKhaki;
+  background-color: {{ g.bg_color | default("DarkKhaki", True) }};
 }
 
 .sah {
@@ -80,10 +80,14 @@ body {
 .ndps {
   margin-left: 25px;
   margin-right: 25px;
-  color: #FFE4C4;
+  color: {{ g.heading_color | default("#FFE4C4", True) }};
   font-size: 35px;
   font-family: monospace;
-  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  {% set heading_outline = g.heading_outline | default("#000", True) %}
+  text-shadow: -1px -1px 0 {{ heading_outline }},
+    1px -1px 0 {{ heading_outline }},
+    -1px 1px 0 {{ heading_outline }},
+    1px 1px 0 {{ heading_outline }};
 }
 
 .pdo {

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -4,7 +4,7 @@
 {% block body %}
 
 <p class="rppl">
-  Děkujeme, že jste se rozhodli účasnit vývoje chatbota {{ scenario }}.
+  Děkujeme, že jste se rozhodli účastnit vývoje chatbota {{ scenario }}.
   V této chvíli se nacházíme ve fázi testování lexikální kompetence.
   Prosíme vás proto o to, abyste chatbotovi odpovídali jednoduchými
   větami a v rámci možností s bohatou slovní zásobou.


### PR DESCRIPTION
Nakonec jsem vymyslel způsob, jak barvy ze scénářů předat šabloně, aniž by se to muselo dělat ručně při každém volání funkce `render_template`, což je trochu pracné. Místo toho se při první příležitosti [navěsí na speciální flaskovský objekt `g`](https://github.com/dlukes/chatbot_scripts/blob/42dff9b69df82bfbff6a53da1bc7f32f6f156ca6/app.py#L91-L93), který je v šablonách [vždy dostupný](https://flask.palletsprojects.com/en/1.1.x/templating/#standard-context), takže [s ním lze pracovat rovnou](https://github.com/dlukes/chatbot_scripts/blob/42dff9b69df82bfbff6a53da1bc7f32f6f156ca6/templates/base.html#L15).

Nejsem si jistý, jestli jsem správně pochopil, o které barvy jde. Kdybyste to ještě chtěl upravit nebo přidat nějaké další, dejte vědět, nebo to případně můžete zkusit sám, z obsahu commitu 78e3f71 by myslím mělo jít relativně snadno vyčíst, jak analogicky doplnit další proměnné tohohle typu.

Jinak jak je patrné z toho, že proměnné jsou definované jen ve `scenario1.py` a ne ve `scenario2.py`, tak když ve scénáři nebudou, použije aplikace defaultní hodnoty definované v šabloně.